### PR TITLE
Add proxy handling for Web requests

### DIFF
--- a/LightBulb/Services/Abstract/WebApiServiceBase.cs
+++ b/LightBulb/Services/Abstract/WebApiServiceBase.cs
@@ -24,11 +24,11 @@ namespace LightBulb.Services.Abstract
             }
             catch (Exception exc)
             {
-                Debug.WriteLine("Error during proxy parsing. " + exc.Message);                
-            }            
+                Debug.WriteLine("Error during proxy parsing. " + exc.Message);
+            }
 
             _client = new HttpClient();
-            _client.DefaultRequestHeaders.Add("User-Agent", "LightBulb (github.com/Tyrrrz/LightBulb)");            
+            _client.DefaultRequestHeaders.Add("User-Agent", "LightBulb (github.com/Tyrrrz/LightBulb)");
         }
 
         /// <summary>

--- a/LightBulb/Services/Abstract/WebApiServiceBase.cs
+++ b/LightBulb/Services/Abstract/WebApiServiceBase.cs
@@ -18,18 +18,16 @@ namespace LightBulb.Services.Abstract
 
         protected WebApiServiceBase()
         {
-            HttpClientHandler httpClientHandler = new HttpClientHandler();
-
             try
             {
-                httpClientHandler.Proxy = GetEnvironmentProxy();                
+                WebRequest.DefaultWebProxy = GetEnvironmentProxy();
             }
             catch (Exception exc)
             {
                 Debug.WriteLine("Error during proxy parsing. " + exc.Message);                
             }            
 
-            _client = new HttpClient(httpClientHandler, true);
+            _client = new HttpClient();
             _client.DefaultRequestHeaders.Add("User-Agent", "LightBulb (github.com/Tyrrrz/LightBulb)");            
         }
 

--- a/LightBulb/Services/Abstract/WebApiServiceBase.cs
+++ b/LightBulb/Services/Abstract/WebApiServiceBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -17,8 +18,49 @@ namespace LightBulb.Services.Abstract
 
         protected WebApiServiceBase()
         {
-            _client = new HttpClient();
-            _client.DefaultRequestHeaders.Add("User-Agent", "LightBulb (github.com/Tyrrrz/LightBulb)");
+            HttpClientHandler httpClientHandler = new HttpClientHandler();
+
+            try
+            {
+                httpClientHandler.Proxy = GetEnvironmentProxy();                
+            }
+            catch (Exception exc)
+            {
+                Debug.WriteLine("Error during proxy parsing. " + exc.Message);                
+            }            
+
+            _client = new HttpClient(httpClientHandler, true);
+            _client.DefaultRequestHeaders.Add("User-Agent", "LightBulb (github.com/Tyrrrz/LightBulb)");            
+        }
+
+        /// <summary>
+        /// Check for the presence of HTTP_PROXY environment variable.
+        /// The proxy value should follow the pattern : [http://][user:password@]host[:port]
+        /// Example : http://192.168.0.1 or john:doe@theproxy.net:3128
+        /// </summary>
+        /// <returns>IWebProxy if valid proxy found; otherwise null. </returns>
+        private IWebProxy GetEnvironmentProxy()
+        {
+            IWebProxy proxy = null;
+            var envProxy = Environment.GetEnvironmentVariable("HTTP_PROXY");
+            if (envProxy != null)
+            {
+                proxy = new WebProxy(envProxy);
+
+                if (envProxy.StartsWith("http://"))
+                {
+                    envProxy = envProxy.Remove(0, 7);
+                }
+
+                if (envProxy.Contains("@"))
+                {
+                    var tmp = envProxy.Split('@');
+                    var auth = tmp[0].Split(':');
+                    proxy.Credentials = new NetworkCredential(auth[0], auth[1]);
+                }
+            }
+
+            return proxy;
         }
 
         /// <summary>


### PR DESCRIPTION
Hi,
I use your (nice) app behind a proxy at work and could not use internet connection. I decided to add proxy handling for Web requests through HTTP_PROXY environment variable.

Just add proxy address and credentials if needed in HTTP_PROXY environment variable following the pattern: [http://][user:password@]host[:port]

I'd rather use the environment more than the settings file since the proxy is used by several apps and can be switched on/off or modified easily.

What's working: geo info, solar info, check for update
What's not working: flag retrieval (Uri binding in xaml)

It may be useful for others !