### PR TITLE
Allow sunset to happen at night

### DIFF
--- a/LightBulb.sln
+++ b/LightBulb.sln
@@ -7,6 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightBulb", "LightBulb\Ligh
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BE19AEAD-02BC-4F40-AC14-D30082A5E78B}"
 	ProjectSection(SolutionItems) = preProject
+		Changelog.md = Changelog.md
 		License.txt = License.txt
 		ReadMe.md = ReadMe.md
 	EndProjectSection

--- a/LightBulb/Internal/Extensions.cs
+++ b/LightBulb/Internal/Extensions.cs
@@ -10,5 +10,10 @@ namespace LightBulb.Internal
             dateTime.TimeOfDay <= timeOfDay
                 ? dateTime.AtTimeOfDay(timeOfDay)
                 : dateTime.AddDays(1).AtTimeOfDay(timeOfDay);
+
+        public static DateTime PreviousTimeOfDay(this DateTime dateTime, TimeSpan timeOfDay) =>
+            dateTime.TimeOfDay > timeOfDay
+                ? dateTime.AtTimeOfDay(timeOfDay)
+                : dateTime.AddDays(-1).AtTimeOfDay(timeOfDay);
     }
 }

--- a/LightBulb/Internal/Extensions.cs
+++ b/LightBulb/Internal/Extensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace LightBulb.Internal
+{
+    internal static class Extensions
+    {
+        public static DateTime AtTimeOfDay(this DateTime dateTime, TimeSpan timeOfDay) => dateTime.Date.Add(timeOfDay);
+
+        public static DateTime NextTimeOfDay(this DateTime dateTime, TimeSpan timeOfDay) =>
+            dateTime.TimeOfDay <= timeOfDay
+                ? dateTime.AtTimeOfDay(timeOfDay)
+                : dateTime.AddDays(1).AtTimeOfDay(timeOfDay);
+    }
+}

--- a/LightBulb/LightBulb.csproj
+++ b/LightBulb/LightBulb.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Helpers\SyncedTimer.cs" />
     <Compile Include="Helpers\Timer.cs" />
     <Compile Include="Helpers\ValueSmoother.cs" />
+    <Compile Include="Internal\Extensions.cs" />
     <Compile Include="Internal\HookManager.cs" />
     <Compile Include="Internal\NativeMethods.cs" />
     <Compile Include="Internal\SpongeWindow.cs" />

--- a/LightBulb/Services/FileSettingsService.cs
+++ b/LightBulb/Services/FileSettingsService.cs
@@ -146,25 +146,13 @@ namespace LightBulb.Services
         public TimeSpan SunriseTime
         {
             get => _sunriseTime;
-            set
-            {
-                if (!Set(ref _sunriseTime, value)) return;
-
-                if (SunriseTime > SunsetTime)
-                    SunsetTime = SunriseTime;
-            }
+            set => Set(ref _sunriseTime, value);
         }
 
         public TimeSpan SunsetTime
         {
             get => _sunsetTime;
-            set
-            {
-                if (!Set(ref _sunsetTime, value)) return;
-
-                if (SunsetTime < SunriseTime)
-                    SunriseTime = SunsetTime;
-            }
+            set => Set(ref _sunsetTime, value);
         }
 
         public GeoInfo GeoInfo

--- a/LightBulb/Services/TemperatureService.cs
+++ b/LightBulb/Services/TemperatureService.cs
@@ -209,13 +209,13 @@ namespace LightBulb.Services
             var sunriseTime = _settingsService.SunriseTime;
             var sunsetTime = _settingsService.SunsetTime;
 
-            //
+            // Get next and previous sunrise and sunset
             var nextSunrise = instant.NextTimeOfDay(sunriseTime);
             var prevSunrise = instant.PreviousTimeOfDay(sunriseTime);
             var nextSunset = instant.NextTimeOfDay(sunsetTime);
             var prevSunset = instant.PreviousTimeOfDay(sunsetTime);
 
-            //
+            // Calculate time until next sunrise and sunset
             var untilNextSunrise = nextSunrise - instant;
             var untilNextSunset = nextSunset - instant;
 
@@ -226,8 +226,8 @@ namespace LightBulb.Services
                 if (instant <= prevSunset.Add(offset))
                 {
                     // Smooth transition
-                    var t = (instant - prevSunset).TotalHours / offset.TotalHours;
-                    return (ushort) (minTemp + (maxTemp - minTemp) * Math.Cos(t * Math.PI / 2));
+                    var norm = (instant - prevSunset).TotalHours / offset.TotalHours;
+                    return (ushort) (minTemp + (maxTemp - minTemp) * Math.Cos(norm * Math.PI / 2));
                 }
 
                 // Night time
@@ -240,8 +240,8 @@ namespace LightBulb.Services
                 if (instant <= prevSunrise.Add(offset))
                 {
                     // Smooth transition
-                    var t = (instant - prevSunrise).TotalHours / offset.TotalHours;
-                    return (ushort) (maxTemp + (minTemp - maxTemp) * Math.Cos(t * Math.PI / 2));
+                    var norm = (instant - prevSunrise).TotalHours / offset.TotalHours;
+                    return (ushort) (maxTemp + (minTemp - maxTemp) * Math.Cos(norm * Math.PI / 2));
                 }
 
                 // Day time

--- a/LightBulb/Views/GeoSettingsView.xaml
+++ b/LightBulb/Views/GeoSettingsView.xaml
@@ -1,39 +1,42 @@
-﻿<UserControl x:Class="LightBulb.Views.GeoSettingsView"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             DataContext="{Binding GeoSettingsViewModel, Source={StaticResource Locator}}">
+﻿<UserControl
+    x:Class="LightBulb.Views.GeoSettingsView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    DataContext="{Binding GeoSettingsViewModel, Source={StaticResource Locator}}">
     <StackPanel Grid.IsSharedSizeScope="True" Orientation="Vertical">
         <!--  Sunrise time temperature  -->
         <TextBlock Margin="5" ToolTip="When the sun rises">
             <Run Text="Sunrise time:" />
             <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="{Binding SettingsService.SunriseTime, StringFormat=\{0:hh\\:mm\}, Mode=OneWay}" />
         </TextBlock>
-        <Slider Margin="7,0,7,5"
-                IsEnabled="{Binding SettingsService.IsInternetSyncEnabled, Converter={StaticResource InvertBoolConverter}}"
-                IsSnapToTickEnabled="True"
-                LargeChange="0.5"
-                Maximum="11"
-                Minimum="4"
-                SmallChange="0.25"
-                TickFrequency="0.25"
-                TickPlacement="BottomRight"
-                Value="{Binding SettingsService.SunriseTime, Converter={StaticResource TimeSpanToHoursConverter}}" />
+        <Slider
+            Margin="7,0,7,5"
+            IsEnabled="{Binding SettingsService.IsInternetSyncEnabled, Converter={StaticResource InvertBoolConverter}}"
+            IsSnapToTickEnabled="True"
+            LargeChange="0.5"
+            Maximum="23.999"
+            Minimum="0"
+            SmallChange="0.25"
+            TickFrequency="0.25"
+            TickPlacement="BottomRight"
+            Value="{Binding SettingsService.SunriseTime, Converter={StaticResource TimeSpanToHoursConverter}}" />
 
         <!--  Sunset time temperature  -->
         <TextBlock Margin="5" ToolTip="When the sun sets">
             <Run Text="Sunset time:" />
             <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="{Binding SettingsService.SunsetTime, StringFormat=\{0:hh\\:mm\}, Mode=OneWay}" />
         </TextBlock>
-        <Slider Margin="7,0,7,5"
-                IsEnabled="{Binding SettingsService.IsInternetSyncEnabled, Converter={StaticResource InvertBoolConverter}}"
-                IsSnapToTickEnabled="True"
-                LargeChange="0.5"
-                Maximum="22"
-                Minimum="15"
-                SmallChange="0.25"
-                TickFrequency="0.25"
-                TickPlacement="BottomRight"
-                Value="{Binding SettingsService.SunsetTime, Converter={StaticResource TimeSpanToHoursConverter}}" />
+        <Slider
+            Margin="7,0,7,5"
+            IsEnabled="{Binding SettingsService.IsInternetSyncEnabled, Converter={StaticResource InvertBoolConverter}}"
+            IsSnapToTickEnabled="True"
+            LargeChange="0.5"
+            Maximum="23.999"
+            Minimum="0"
+            SmallChange="0.25"
+            TickFrequency="0.25"
+            TickPlacement="BottomRight"
+            Value="{Binding SettingsService.SunsetTime, Converter={StaticResource TimeSpanToHoursConverter}}" />
 
         <!--  Internet sync on/off  -->
         <Grid Margin="5">
@@ -42,14 +45,16 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <TextBlock Grid.Column="0"
-                       VerticalAlignment="Center"
-                       Text="Internet synchronization:"
-                       ToolTip="Pull sunrise and sunset times for your location from the Internet" />
-            <ToggleButton Grid.Column="1"
-                          HorizontalAlignment="Right"
-                          VerticalAlignment="Center"
-                          IsChecked="{Binding SettingsService.IsInternetSyncEnabled}" />
+            <TextBlock
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="Internet synchronization:"
+                ToolTip="Pull sunrise and sunset times for your location from the Internet" />
+            <ToggleButton
+                Grid.Column="1"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Center"
+                IsChecked="{Binding SettingsService.IsInternetSyncEnabled}" />
         </Grid>
 
         <!--  Geoinfo (when set)  -->
@@ -61,17 +66,19 @@
             </Grid.ColumnDefinitions>
 
             <!--  Country flag  -->
-            <Image Grid.Column="0"
-                   Width="16"
-                   Height="16"
-                   VerticalAlignment="Center"
-                   Source="{Binding GeoInfoCountryFlagUrl, IsAsync=True}" />
+            <Image
+                Grid.Column="0"
+                Width="16"
+                Height="16"
+                VerticalAlignment="Center"
+                Source="{Binding GeoInfoCountryFlagUrl, IsAsync=True}" />
 
             <!--  Geoinfo is set  -->
-            <TextBlock Grid.Column="1"
-                       Margin="3,0,0,0"
-                       VerticalAlignment="Top"
-                       TextWrapping="Wrap">
+            <TextBlock
+                Grid.Column="1"
+                Margin="3,0,0,0"
+                VerticalAlignment="Top"
+                TextWrapping="Wrap">
                 <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="{Binding SettingsService.GeoInfo.City, Mode=OneWay, TargetNullValue=???}" />
                 <Run Text="/" />
                 <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="{Binding SettingsService.GeoInfo.Country, Mode=OneWay, TargetNullValue=???}" />
@@ -83,9 +90,10 @@
         </Grid>
 
         <!--  Geoinfo (when not set)  -->
-        <TextBlock Margin="5,0,5,5"
-                   Foreground="{DynamicResource PrimaryTextBrush}"
-                   Text="&lt; not set &gt;"
-                   Visibility="{Binding IsGeoInfoSet, Converter={StaticResource InvertBoolToVisibilityConverter}, ConverterParameter={x:Static Visibility.Collapsed}}" />
+        <TextBlock
+            Margin="5,0,5,5"
+            Foreground="{DynamicResource PrimaryTextBrush}"
+            Text="&lt; not set &gt;"
+            Visibility="{Binding IsGeoInfoSet, Converter={StaticResource InvertBoolToVisibilityConverter}, ConverterParameter={x:Static Visibility.Collapsed}}" />
     </StackPanel>
 </UserControl>

--- a/LightBulb/Views/GeoSettingsView.xaml
+++ b/LightBulb/Views/GeoSettingsView.xaml
@@ -12,12 +12,11 @@
         <Slider
             Margin="7,0,7,5"
             IsEnabled="{Binding SettingsService.IsInternetSyncEnabled, Converter={StaticResource InvertBoolConverter}}"
-            IsSnapToTickEnabled="True"
             LargeChange="0.5"
-            Maximum="23.999"
+            Maximum="24"
             Minimum="0"
             SmallChange="0.25"
-            TickFrequency="0.25"
+            TickFrequency="1"
             TickPlacement="BottomRight"
             Value="{Binding SettingsService.SunriseTime, Converter={StaticResource TimeSpanToHoursConverter}}" />
 
@@ -29,12 +28,11 @@
         <Slider
             Margin="7,0,7,5"
             IsEnabled="{Binding SettingsService.IsInternetSyncEnabled, Converter={StaticResource InvertBoolConverter}}"
-            IsSnapToTickEnabled="True"
             LargeChange="0.5"
-            Maximum="23.999"
+            Maximum="24"
             Minimum="0"
             SmallChange="0.25"
-            TickFrequency="0.25"
+            TickFrequency="1"
             TickPlacement="BottomRight"
             Value="{Binding SettingsService.SunsetTime, Converter={StaticResource TimeSpanToHoursConverter}}" />
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ deploy:
   auth_token:
     secure: sjQHWRw29AMiVMn3MtidtWnAzAf1mJ+mkJ/7h1B9TIAHhkFrqwMK7LtXV+uNJ9AO
   artifact: LightBulb-Installer.exe,LightBulb-Portable.zip
-  draft: true
+  description: '[Changelog](https://github.com/Tyrrrz/LightBulb/blob/master/Changelog.md)'
   on:
     branch: master
     appveyor_repo_tag: true


### PR DESCRIPTION
Fix issues in the temperature calculation algorithm that would prevent LightBulb from functioning properly when sunset is set to occur at night.
Also lets users configure sunrise and sunset to any value, via the UI.

Fixes #78 
Closes #20 