### PR TITLE
Produce self-contained builds of the app

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   pack:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     permissions:
@@ -95,7 +95,8 @@ jobs:
           -p:CSharpier_Bypass=true
           --output LightBulb/bin/publish/
           --configuration Release
-          --use-current-runtime
+          --runtime win-x64
+          --self-contained
 
       - name: Create installer
         shell: pwsh

--- a/LightBulb/LightBulb.csproj
+++ b/LightBulb/LightBulb.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="CSharpier.MsBuild" Version="0.28.1" PrivateAssets="all" />
     <PackageReference Include="Deorcify" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="DialogHost.Avalonia" Version="0.7.7" />
-    <PackageReference Include="DotnetRuntimeBootstrapper" Version="2.5.3" PrivateAssets="all" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
     <PackageReference Include="Material.Avalonia" Version="3.5.0" />
     <PackageReference Include="Material.Icons.Avalonia" Version="2.1.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />


### PR DESCRIPTION
Produce self-contained builds of LightBulb that don't require manual installation of .NET, with the downside of a much larger download size.

With the usage of Avalonia, this has become viable as it has a lot smaller file size overhead compared to WPF.