### PR TITLE
Dark mode

### DIFF
--- a/LightBulb/App.axaml
+++ b/LightBulb/App.axaml
@@ -135,26 +135,25 @@
     </Application.Styles>
 
     <Application.Resources>
-        <!--  Text box  -->
-        <ControlTheme
-            x:Key="CompactTextBox"
-            BasedOn="{StaticResource {x:Type TextBox}}"
-            TargetType="{x:Type TextBox}">
-            <Styles>
-                <Style Selector="TextBox">
-                    <Setter Property="Height" Value="22" />
-
-                    <Style Selector="^ /template/ Panel#PART_TextFieldPanel">
-                        <Setter Property="MinHeight" Value="0" />
-                    </Style>
-                    <Style Selector="^ /template/ Panel#PART_TextContainer">
-                        <Setter Property="Margin" Value="0" />
-                    </Style>
-                </Style>
-            </Styles>
-        </ControlTheme>
-
         <ResourceDictionary>
+            <!--  Text box  -->
+            <ControlTheme
+                x:Key="CompactTextBox"
+                BasedOn="{StaticResource {x:Type TextBox}}"
+                TargetType="{x:Type TextBox}">
+                <Styles>
+                    <Style Selector="TextBox">
+                        <Setter Property="Height" Value="22" />
+
+                        <Style Selector="^ /template/ Panel#PART_TextFieldPanel">
+                            <Setter Property="MinHeight" Value="0" />
+                        </Style>
+                        <Style Selector="^ /template/ Panel#PART_TextContainer">
+                            <Setter Property="Margin" Value="0" />
+                        </Style>
+                    </Style>
+                </Styles>
+            </ControlTheme>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
                     <!-- Sundial brushes -->

--- a/LightBulb/App.axaml
+++ b/LightBulb/App.axaml
@@ -170,33 +170,11 @@
             </ControlTheme>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
-                    <!-- Sundial brushes -->
-                    <SolidColorBrush x:Key="SundialNightBorderBrush" Color="#FFAF1A"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialNightBrush" Color="#FFD280"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialDayBorderBrush" Color="#8AC0FF"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialDayBrush" Color="#F2F8FF"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialSunriseBorderBrush" Color="#FFC766"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialSunriseBrush" Color="#FFEDCD"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialSunsetBorderBrush" Color="#FFC766"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialSunsetBrush" Color="#FFEDCD"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialMarkerBorderBrush" Color="#FF7733"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialMarkerBrush" Color="#FFAB85"></SolidColorBrush>
                     <!-- Custom style for disabled toggles -->
                     <SolidColorBrush x:Key="ToggleBackgroundBrush" Color="#FFFFFF"></SolidColorBrush>
                     <sys:Boolean x:Key="UseAccentControls">false</sys:Boolean>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Dark">
-                    <!-- Sundial brushes -->
-                    <SolidColorBrush x:Key="SundialNightBorderBrush" Color="#B18B4E"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialNightBrush" Color="#ECC17E"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialDayBorderBrush" Color="#4E93B1"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialDayBrush" Color="#AAD7EA"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialSunriseBorderBrush" Color="#B18C4E"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialSunriseBrush" Color="#FAEDD6"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialSunsetBorderBrush" Color="#B18C4E"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialSunsetBrush" Color="#FAEDD6"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialMarkerBorderBrush" Color="#B1704E"></SolidColorBrush>
-                    <SolidColorBrush x:Key="SundialMarkerBrush" Color="#E38755"></SolidColorBrush>
                     <!-- Custom style for disabled toggles -->
                     <SolidColorBrush x:Key="ToggleBackgroundBrush" Color="#8E8E8E"></SolidColorBrush>
                     <sys:Boolean x:Key="UseAccentControls">true</sys:Boolean>

--- a/LightBulb/App.axaml
+++ b/LightBulb/App.axaml
@@ -11,8 +11,27 @@
         <framework:ViewManager />
     </Application.DataTemplates>
 
+	<Application.Resources>
+		<!-- Override theme Primary color -->
+		<SolidColorBrush x:Key="MaterialPrimaryLightBrush" Color="#343838"></SolidColorBrush>
+		<SolidColorBrush x:Key="MaterialPrimaryLightForegroundBrush" Color="#343838"></SolidColorBrush>
+		<SolidColorBrush x:Key="MaterialPrimaryMidBrush" Color="#343838"></SolidColorBrush>
+		<SolidColorBrush x:Key="MaterialPrimaryMidForegroundBrush" Color="White"></SolidColorBrush>
+		<SolidColorBrush x:Key="MaterialPrimaryDarkBrush" Color="#343838"></SolidColorBrush>
+		<SolidColorBrush x:Key="MaterialPrimaryForegroundBrush" Color="#343838"></SolidColorBrush>
+
+		<!-- Override theme Secondary color -->
+		<SolidColorBrush x:Key="MaterialSecondaryLightBrush" Color="#F9A825"></SolidColorBrush>
+		<SolidColorBrush x:Key="MaterialSecondaryLightForegroundBrush" Color="#F9A825"></SolidColorBrush>
+		<SolidColorBrush x:Key="MaterialSecondaryMidBrush" Color="#F9A825"></SolidColorBrush>
+		<SolidColorBrush x:Key="MaterialSecondaryMidForegroundBrush" Color="#F9A825"></SolidColorBrush>
+		<SolidColorBrush x:Key="MaterialSecondaryDarkBrush" Color="#F9A825"></SolidColorBrush>
+		<SolidColorBrush x:Key="MaterialSecondaryDarkForegroundBrush" Color="#F9A825"></SolidColorBrush>
+	</Application.Resources>
+	
     <Application.Styles>
-        <materialStyles:MaterialTheme />
+		<!-- Dummy values for foreground colors to initialize properly. All associated brushes are overridden in Application.Resources. -->
+        <materialStyles:MaterialTheme BaseTheme="Light" PrimaryColor="Purple" SecondaryColor="Green"/>
         <materialIcons:MaterialIconStyles />
         <dialogHostAvalonia:DialogHostStyles />
 

--- a/LightBulb/App.axaml
+++ b/LightBulb/App.axaml
@@ -118,6 +118,20 @@
             <Setter Property="TextElement.FontWeight" Value="Medium" />
         </Style>
 
+        <!-- Combo box -->
+        <Style Selector="ComboBox">
+            <Style Selector="^ /template/ Panel#PART_RootPanel">
+                <Setter Property="Height" Value="22" />
+            </Style>
+        </Style>
+
+        <!-- Apply ComboBox Accent class, since material doesn't do it itself -->
+        <Style Selector="ComboBox.accent">
+            <Style Selector="^ materialControls|MaterialUnderline">
+                <Setter Property="ActiveBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+            </Style>
+        </Style>
+
         <!--  Toggle switch  -->
         <Style Selector="ToggleSwitch">
             <!-- Apply custom style for disabled toggles, because Material's default is bad.-->

--- a/LightBulb/App.axaml
+++ b/LightBulb/App.axaml
@@ -22,7 +22,7 @@
                 </ResourceDictionary>
             </Style.Resources>
         </Style>
-        
+
         <materialStyles:MaterialThemeBase />
         <materialIcons:MaterialIconStyles />
         <dialogHostAvalonia:DialogHostStyles />
@@ -98,40 +98,40 @@
             </Style>
         </Style>
 
-		<!--  Text box  -->
-		<Style Selector="TextBox">
-			<Setter Property="FontSize" Value="14" />
-		</Style>
+        <!--  Text box  -->
+        <Style Selector="TextBox">
+            <Setter Property="FontSize" Value="14" />
+        </Style>
 
-		<!-- Apply TextBox Accent class, since material doesn't do it itself -->
-		<Style Selector="TextBox.accent">
-			<Setter Property="SelectionBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
-			<Setter Property="SelectionForegroundBrush" Value="{DynamicResource MaterialSecondaryForegroundBrush}" />
-			<Setter Property="CaretBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
-			<Style Selector="^ materialControls|MaterialUnderline">
-				<Setter Property="ActiveBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
-			</Style>
-		</Style>
+        <!-- Apply TextBox Accent class, since material doesn't do it itself -->
+        <Style Selector="TextBox.accent">
+            <Setter Property="SelectionBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+            <Setter Property="SelectionForegroundBrush" Value="{DynamicResource MaterialSecondaryForegroundBrush}" />
+            <Setter Property="CaretBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+            <Style Selector="^ materialControls|MaterialUnderline">
+                <Setter Property="ActiveBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+            </Style>
+        </Style>
 
-		<!--  Toggle button  -->
-		<Style Selector="ToggleButton">
-			<Setter Property="TextElement.FontWeight" Value="Medium" />
-		</Style>
+        <!--  Toggle button  -->
+        <Style Selector="ToggleButton">
+            <Setter Property="TextElement.FontWeight" Value="Medium" />
+        </Style>
 
-		<!--  Toggle switch  -->
-		<Style Selector="ToggleSwitch">
-			<!-- Apply custom style for disabled toggles, because Material's default is bad.-->
-			<!-- Tracked in https://github.com/AvaloniaCommunity/Material.Avalonia/issues/379 -->
-			<Setter Property="materialAssists:ToggleSwitchAssist.SwitchThumbOffBackground" Value="{DynamicResource ToggleBackgroundBrush}" />
-		</Style>
+        <!--  Toggle switch  -->
+        <Style Selector="ToggleSwitch">
+            <!-- Apply custom style for disabled toggles, because Material's default is bad.-->
+            <!-- Tracked in https://github.com/AvaloniaCommunity/Material.Avalonia/issues/379 -->
+            <Setter Property="materialAssists:ToggleSwitchAssist.SwitchThumbOffBackground" Value="{DynamicResource ToggleBackgroundBrush}" />
+        </Style>
 
-		<!--  Tooltip  -->
-		<Style Selector="ToolTip">
-			<Setter Property="TextElement.FontSize" Value="14" />
-			<Setter Property="TextElement.FontWeight" Value="Normal" />
-			<Setter Property="TextElement.FontStyle" Value="Normal" />
-			<Setter Property="TextElement.FontStretch" Value="Normal" />
-		</Style>
+        <!--  Tooltip  -->
+        <Style Selector="ToolTip">
+            <Setter Property="TextElement.FontSize" Value="14" />
+            <Setter Property="TextElement.FontWeight" Value="Normal" />
+            <Setter Property="TextElement.FontStyle" Value="Normal" />
+            <Setter Property="TextElement.FontStretch" Value="Normal" />
+        </Style>
     </Application.Styles>
 
     <Application.Resources>
@@ -154,42 +154,42 @@
             </Styles>
         </ControlTheme>
 
-		<ResourceDictionary>
-			<ResourceDictionary.ThemeDictionaries>
-				<ResourceDictionary x:Key="Light">
-					<!-- Sundial brushes -->
-					<SolidColorBrush x:Key="SundialNightBorderBrush" Color="#FFAF1A"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialNightBrush" Color="#FFD280"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialDayBorderBrush" Color="#8AC0FF"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialDayBrush" Color="#F2F8FF"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialSunriseBorderBrush" Color="#FFC766"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialSunriseBrush" Color="#FFEDCD"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialSunsetBorderBrush" Color="#FFC766"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialSunsetBrush" Color="#FFEDCD"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialMarkerBorderBrush" Color="#FF7733"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialMarkerBrush" Color="#FFAB85"></SolidColorBrush>
-					<!-- Custom style for disabled toggles -->
-					<SolidColorBrush x:Key="ToggleBackgroundBrush" Color="#FFFFFF"></SolidColorBrush>
-					<sys:Boolean x:Key="UseAccentControls">false</sys:Boolean>
-				</ResourceDictionary>
-				<ResourceDictionary x:Key="Dark">
-					<!-- Sundial brushes -->
-					<SolidColorBrush x:Key="SundialNightBorderBrush" Color="#B18B4E"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialNightBrush" Color="#ECC17E"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialDayBorderBrush" Color="#4E93B1"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialDayBrush" Color="#AAD7EA"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialSunriseBorderBrush" Color="#B18C4E"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialSunriseBrush" Color="#FAEDD6"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialSunsetBorderBrush" Color="#B18C4E"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialSunsetBrush" Color="#FAEDD6"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialMarkerBorderBrush" Color="#B1704E"></SolidColorBrush>
-					<SolidColorBrush x:Key="SundialMarkerBrush" Color="#E38755"></SolidColorBrush>
-					<!-- Custom style for disabled toggles -->
-					<SolidColorBrush x:Key="ToggleBackgroundBrush" Color="#8E8E8E"></SolidColorBrush>
-					<sys:Boolean x:Key="UseAccentControls">true</sys:Boolean>
-				</ResourceDictionary>
-			</ResourceDictionary.ThemeDictionaries>
-		</ResourceDictionary>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <!-- Sundial brushes -->
+                    <SolidColorBrush x:Key="SundialNightBorderBrush" Color="#FFAF1A"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialNightBrush" Color="#FFD280"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialDayBorderBrush" Color="#8AC0FF"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialDayBrush" Color="#F2F8FF"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunriseBorderBrush" Color="#FFC766"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunriseBrush" Color="#FFEDCD"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunsetBorderBrush" Color="#FFC766"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunsetBrush" Color="#FFEDCD"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialMarkerBorderBrush" Color="#FF7733"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialMarkerBrush" Color="#FFAB85"></SolidColorBrush>
+                    <!-- Custom style for disabled toggles -->
+                    <SolidColorBrush x:Key="ToggleBackgroundBrush" Color="#FFFFFF"></SolidColorBrush>
+                    <sys:Boolean x:Key="UseAccentControls">false</sys:Boolean>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <!-- Sundial brushes -->
+                    <SolidColorBrush x:Key="SundialNightBorderBrush" Color="#B18B4E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialNightBrush" Color="#ECC17E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialDayBorderBrush" Color="#4E93B1"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialDayBrush" Color="#AAD7EA"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunriseBorderBrush" Color="#B18C4E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunriseBrush" Color="#FAEDD6"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunsetBorderBrush" Color="#B18C4E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunsetBrush" Color="#FAEDD6"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialMarkerBorderBrush" Color="#B1704E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialMarkerBrush" Color="#E38755"></SolidColorBrush>
+                    <!-- Custom style for disabled toggles -->
+                    <SolidColorBrush x:Key="ToggleBackgroundBrush" Color="#8E8E8E"></SolidColorBrush>
+                    <sys:Boolean x:Key="UseAccentControls">true</sys:Boolean>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 
     <!--  Tray icon  -->

--- a/LightBulb/App.axaml
+++ b/LightBulb/App.axaml
@@ -11,27 +11,17 @@
         <framework:ViewManager />
     </Application.DataTemplates>
 
-	<Application.Resources>
-		<!-- Override theme Primary color -->
-		<SolidColorBrush x:Key="MaterialPrimaryLightBrush" Color="#343838"></SolidColorBrush>
-		<SolidColorBrush x:Key="MaterialPrimaryLightForegroundBrush" Color="#343838"></SolidColorBrush>
-		<SolidColorBrush x:Key="MaterialPrimaryMidBrush" Color="#343838"></SolidColorBrush>
-		<SolidColorBrush x:Key="MaterialPrimaryMidForegroundBrush" Color="White"></SolidColorBrush>
-		<SolidColorBrush x:Key="MaterialPrimaryDarkBrush" Color="#343838"></SolidColorBrush>
-		<SolidColorBrush x:Key="MaterialPrimaryForegroundBrush" Color="#343838"></SolidColorBrush>
+	<Application.Styles>
+		<Style>
+			<Style.Resources>
+				<ResourceDictionary>
+					<!-- Fix bug with initialization of MaterialPaperBrush using MaterialThemeBase -->
+					<SolidColorBrush x:Key="MaterialPaperBrush" Color="#FF0000"></SolidColorBrush>
+				</ResourceDictionary>
+			</Style.Resources>
+		</Style>
 
-		<!-- Override theme Secondary color -->
-		<SolidColorBrush x:Key="MaterialSecondaryLightBrush" Color="#F9A825"></SolidColorBrush>
-		<SolidColorBrush x:Key="MaterialSecondaryLightForegroundBrush" Color="#F9A825"></SolidColorBrush>
-		<SolidColorBrush x:Key="MaterialSecondaryMidBrush" Color="#F9A825"></SolidColorBrush>
-		<SolidColorBrush x:Key="MaterialSecondaryMidForegroundBrush" Color="#F9A825"></SolidColorBrush>
-		<SolidColorBrush x:Key="MaterialSecondaryDarkBrush" Color="#F9A825"></SolidColorBrush>
-		<SolidColorBrush x:Key="MaterialSecondaryDarkForegroundBrush" Color="#F9A825"></SolidColorBrush>
-	</Application.Resources>
-	
-    <Application.Styles>
-		<!-- Dummy values for foreground colors to initialize properly. All associated brushes are overridden in Application.Resources. -->
-        <materialStyles:MaterialTheme BaseTheme="Light" PrimaryColor="Purple" SecondaryColor="Green"/>
+        <materialStyles:MaterialThemeBase />
         <materialIcons:MaterialIconStyles />
         <dialogHostAvalonia:DialogHostStyles />
 

--- a/LightBulb/App.axaml
+++ b/LightBulb/App.axaml
@@ -4,23 +4,64 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:dialogHostAvalonia="clr-namespace:DialogHostAvalonia;assembly=DialogHost.Avalonia"
     xmlns:framework="clr-namespace:LightBulb.Framework"
+    xmlns:sys="using:System"
     xmlns:materialAssists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
+    xmlns:materialControls="clr-namespace:Material.Styles.Controls;assembly=Material.Styles"
     xmlns:materialIcons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
     xmlns:materialStyles="clr-namespace:Material.Styles.Themes;assembly=Material.Styles">
     <Application.DataTemplates>
         <framework:ViewManager />
     </Application.DataTemplates>
 
-	<Application.Styles>
-		<Style>
-			<Style.Resources>
-				<ResourceDictionary>
-					<!-- Fix bug with initialization of MaterialPaperBrush using MaterialThemeBase -->
-					<SolidColorBrush x:Key="MaterialPaperBrush" Color="#FF0000"></SolidColorBrush>
-				</ResourceDictionary>
-			</Style.Resources>
-		</Style>
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <!-- Sundial brushes -->
+                    <SolidColorBrush x:Key="SundialNightBorderBrush" Color="#FFAF1A"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialNightBrush" Color="#FFD280"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialDayBorderBrush" Color="#8AC0FF"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialDayBrush" Color="#F2F8FF"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunriseBorderBrush" Color="#FFC766"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunriseBrush" Color="#FFEDCD"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunsetBorderBrush" Color="#FFC766"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunsetBrush" Color="#FFEDCD"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialMarkerBorderBrush" Color="#FF7733"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialMarkerBrush" Color="#FFAB85"></SolidColorBrush>
+                    <!-- Custom style for disabled toggles -->
+                    <SolidColorBrush x:Key="ToggleBackgroundBrush" Color="#FFFFFF"></SolidColorBrush>
+                    <sys:Boolean x:Key="UseAccentControls">false</sys:Boolean>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <!-- Sundial brushes -->
+                    <SolidColorBrush x:Key="SundialNightBorderBrush" Color="#B18B4E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialNightBrush" Color="#ECC17E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialDayBorderBrush" Color="#4E93B1"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialDayBrush" Color="#AAD7EA"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunriseBorderBrush" Color="#B18C4E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunriseBrush" Color="#FAEDD6"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunsetBorderBrush" Color="#B18C4E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunsetBrush" Color="#FAEDD6"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialMarkerBorderBrush" Color="#B1704E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialMarkerBrush" Color="#E38755"></SolidColorBrush>
+                    <!-- Custom style for disabled toggles -->
+                    <SolidColorBrush x:Key="ToggleBackgroundBrush" Color="#8E8E8E"></SolidColorBrush>
+                    <sys:Boolean x:Key="UseAccentControls">true</sys:Boolean>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
 
+    <Application.Styles>
+        <Style>
+            <Style.Resources>
+                <ResourceDictionary>
+                    <!-- Fix bug with initialization of MaterialPaperBrush using MaterialThemeBase -->
+                    <SolidColorBrush x:Key="MaterialPaperBrush" Color="#FF0000"></SolidColorBrush>
+                </ResourceDictionary>
+            </Style.Resources>
+        </Style>
+        
         <materialStyles:MaterialThemeBase />
         <materialIcons:MaterialIconStyles />
         <dialogHostAvalonia:DialogHostStyles />
@@ -79,6 +120,23 @@
             </Style>
         </Style>
 
+        <!-- Apply Slider Accent class, since Material doesn't do it itself -->
+        <Style Selector="Slider.accent">
+            <Style Selector="^ Border#PART_InactiveState">
+                <Setter Property="Background" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+            </Style>
+            <Style Selector="^ Border#PART_Indicator">
+                <Setter Property="Background" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+            </Style>
+            <Style Selector="^ Border#PART_HoverEffect">
+                <Setter Property="Background" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+            </Style>
+
+            <Style Selector="^ Border#PART_ThumbGrip">
+                <Setter Property="Background" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+            </Style>
+        </Style>
+        
         <!--  Text box  -->
         <Style Selector="TextBox">
             <Setter Property="Height" Value="22" />
@@ -93,6 +151,16 @@
             </Style>
         </Style>
 
+        <!-- Apply TextBox Accent class, since material doesn't do it itself -->
+        <Style Selector="TextBox.accent">
+            <Setter Property="SelectionBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+            <Setter Property="SelectionForegroundBrush" Value="{DynamicResource MaterialSecondaryForegroundBrush}" />
+            <Setter Property="CaretBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+            <Style Selector="^ materialControls|MaterialUnderline">
+                <Setter Property="ActiveBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+            </Style>
+        </Style>
+
         <!--  Tooltip  -->
         <Style Selector="ToolTip">
             <Setter Property="TextElement.FontSize" Value="14" />
@@ -103,7 +171,9 @@
 
         <!--  Toggle switch  -->
         <Style Selector="ToggleSwitch">
-            <Setter Property="materialAssists:ToggleSwitchAssist.SwitchThumbOffBackground" Value="{DynamicResource MaterialBackgroundBrush}" />
+            <!-- Apply custom style for disabled toggles, because Material's default is bad.-->
+            <!-- Tracked in https://github.com/AvaloniaCommunity/Material.Avalonia/issues/379 -->
+            <Setter Property="materialAssists:ToggleSwitchAssist.SwitchThumbOffBackground" Value="{DynamicResource ToggleBackgroundBrush}" />
         </Style>
     </Application.Styles>
 

--- a/LightBulb/App.axaml.cs
+++ b/LightBulb/App.axaml.cs
@@ -4,7 +4,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
-using Avalonia.Media;
 using Avalonia.Threading;
 using LightBulb.Framework;
 using LightBulb.Services;
@@ -15,7 +14,6 @@ using LightBulb.ViewModels.Components;
 using LightBulb.ViewModels.Components.Settings;
 using LightBulb.ViewModels.Dialogs;
 using LightBulb.Views;
-using Material.Styles.Themes;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LightBulb;
@@ -94,13 +92,6 @@ public class App : Application, IDisposable
             desktopLifetime.MainWindow = new MainView { DataContext = _mainViewModel };
 
         base.OnFrameworkInitializationCompleted();
-
-        // Set custom theme colors
-        this.LocateMaterialTheme<MaterialThemeBase>().CurrentTheme = Theme.Create(
-            Theme.Light,
-            Color.Parse("#343838"),
-            Color.Parse("#F9A825")
-        );
     }
 
     private void ShowMainWindow()

--- a/LightBulb/App.axaml.cs
+++ b/LightBulb/App.axaml.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Platform;
 using Avalonia.Threading;
 using LightBulb.Framework;
 using LightBulb.Services;
@@ -14,6 +17,8 @@ using LightBulb.ViewModels.Components;
 using LightBulb.ViewModels.Components.Settings;
 using LightBulb.ViewModels.Dialogs;
 using LightBulb.Views;
+using Material.Colors.ColorManipulation;
+using Material.Styles.Themes;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LightBulb;
@@ -92,6 +97,42 @@ public class App : Application, IDisposable
             desktopLifetime.MainWindow = new MainView { DataContext = _mainViewModel };
 
         base.OnFrameworkInitializationCompleted();
+
+        if (PlatformSettings is IPlatformSettings settings)
+        {
+            settings.ColorValuesChanged += PlatformSettings_ColorValuesChanged;
+            SetupTheme(settings.GetColorValues());
+        }
+    }
+
+    private void PlatformSettings_ColorValuesChanged(object? sender, PlatformColorValues colors)
+    {
+        SetupTheme(colors);
+    }
+
+    private void SetupTheme(PlatformColorValues colors)
+    {
+        if (colors.ThemeVariant == PlatformThemeVariant.Dark)
+        {
+            // Set custom theme colors
+            var theme = Theme.Create(
+                Theme.Dark,
+                Color.Parse("#343838").Darken(),
+                Color.Parse("#F9A825")
+            );
+            // Exclusively effects disabled toggle color
+            theme.Background = Color.Parse("#343838").Lighten();
+            this.LocateMaterialTheme<MaterialThemeBase>().CurrentTheme = theme;
+        }
+        else
+        {
+            // Set custom theme colors
+            this.LocateMaterialTheme<MaterialThemeBase>().CurrentTheme = Theme.Create(
+                Theme.Light,
+                Color.Parse("#343838"),
+                Color.Parse("#F9A825")
+            );
+        }
     }
 
     private void ShowMainWindow()

--- a/LightBulb/App.axaml.cs
+++ b/LightBulb/App.axaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
@@ -17,7 +16,6 @@ using LightBulb.ViewModels.Components;
 using LightBulb.ViewModels.Components.Settings;
 using LightBulb.ViewModels.Dialogs;
 using LightBulb.Views;
-using Material.Colors.ColorManipulation;
 using Material.Styles.Themes;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -114,19 +112,14 @@ public class App : Application, IDisposable
     {
         if (colors.ThemeVariant == PlatformThemeVariant.Dark)
         {
-            // Set custom theme colors
-            var theme = Theme.Create(
+            this.LocateMaterialTheme<MaterialThemeBase>().CurrentTheme = Theme.Create(
                 Theme.Dark,
-                Color.Parse("#343838").Darken(),
+                Color.Parse("#202222"),
                 Color.Parse("#F9A825")
             );
-            // Exclusively effects disabled toggle color
-            theme.Background = Color.Parse("#343838").Lighten();
-            this.LocateMaterialTheme<MaterialThemeBase>().CurrentTheme = theme;
         }
         else
         {
-            // Set custom theme colors
             this.LocateMaterialTheme<MaterialThemeBase>().CurrentTheme = Theme.Create(
                 Theme.Light,
                 Color.Parse("#343838"),

--- a/LightBulb/LightBulb.csproj
+++ b/LightBulb/LightBulb.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Deorcify" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="DialogHost.Avalonia" Version="0.7.7" />
     <PackageReference Include="DotnetRuntimeBootstrapper" Version="2.5.3" PrivateAssets="all" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
-    <PackageReference Include="Material.Avalonia" Version="3.5.0" />
+    <PackageReference Include="Material.Avalonia" Version="3.6.0" />
     <PackageReference Include="Material.Icons.Avalonia" Version="2.1.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Onova" Version="2.6.11" />

--- a/LightBulb/Models/ThemeMode.cs
+++ b/LightBulb/Models/ThemeMode.cs
@@ -1,0 +1,22 @@
+﻿namespace LightBulb.Models;
+
+/// <summary>
+/// Describes the application's theme mode.
+/// </summary>
+public enum ThemeMode
+{
+    /// <summary>
+    /// Use the light theme
+    /// </summary>
+    Light,
+
+    /// <summary>
+    /// Use the dark theme
+    /// </summary>
+    Dark,
+
+    /// <summary>
+    /// Use whichever theme is specified by system settings
+    /// </summary>
+    System
+}

--- a/LightBulb/Services/SettingsService.cs
+++ b/LightBulb/Services/SettingsService.cs
@@ -89,6 +89,9 @@ public partial class SettingsService() : SettingsBase(GetFilePath())
     private bool _isAutoStartEnabled;
 
     [ObservableProperty]
+    private ThemeMode _theme = ThemeMode.System;
+
+    [ObservableProperty]
     private bool _isAutoUpdateEnabled = true;
 
     [ObservableProperty]

--- a/LightBulb/ViewModels/Components/Settings/AdvancedSettingsTabViewModel.cs
+++ b/LightBulb/ViewModels/Components/Settings/AdvancedSettingsTabViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using LightBulb.Models;
 using LightBulb.Services;
 
@@ -13,7 +14,7 @@ public class AdvancedSettingsTabViewModel(SettingsService settingsService)
         set => SettingsService.IsAutoStartEnabled = value;
     }
 
-    public Array ThemeArray { get; } = Enum.GetValues<ThemeMode>();
+    public IReadOnlyList<ThemeMode> ThemeArray { get; } = Enum.GetValues<ThemeMode>();
 
     public ThemeMode Theme
     {

--- a/LightBulb/ViewModels/Components/Settings/AdvancedSettingsTabViewModel.cs
+++ b/LightBulb/ViewModels/Components/Settings/AdvancedSettingsTabViewModel.cs
@@ -1,4 +1,6 @@
-﻿using LightBulb.Services;
+﻿using System;
+using LightBulb.Models;
+using LightBulb.Services;
 
 namespace LightBulb.ViewModels.Components.Settings;
 
@@ -9,6 +11,14 @@ public class AdvancedSettingsTabViewModel(SettingsService settingsService)
     {
         get => SettingsService.IsAutoStartEnabled;
         set => SettingsService.IsAutoStartEnabled = value;
+    }
+
+    public Array ThemeArray { get; } = Enum.GetValues<ThemeMode>();
+
+    public ThemeMode Theme
+    {
+        get => SettingsService.Theme;
+        set => SettingsService.Theme = value;
     }
 
     public bool IsAutoUpdateEnabled

--- a/LightBulb/ViewModels/MainViewModel.cs
+++ b/LightBulb/ViewModels/MainViewModel.cs
@@ -143,9 +143,6 @@ public partial class MainViewModel(
     [RelayCommand]
     private async Task InitializeAsync()
     {
-        // Load settings
-        settingsService.Load();
-
         await FinalizePendingUpdateAsync();
         await ShowGammaRangePromptAsync();
         await ShowFirstTimeExperienceMessageAsync();

--- a/LightBulb/Views/Components/DashboardView.axaml
+++ b/LightBulb/Views/Components/DashboardView.axaml
@@ -12,6 +12,39 @@
         <components:DashboardViewModel />
     </Design.DataContext>
 
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <!-- Sundial brushes -->
+                    <SolidColorBrush x:Key="SundialNightBorderBrush" Color="#FFAF1A"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialNightBrush" Color="#FFD280"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialDayBorderBrush" Color="#8AC0FF"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialDayBrush" Color="#F2F8FF"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunriseBorderBrush" Color="#FFC766"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunriseBrush" Color="#FFEDCD"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunsetBorderBrush" Color="#FFC766"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunsetBrush" Color="#FFEDCD"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialMarkerBorderBrush" Color="#FF7733"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialMarkerBrush" Color="#FFAB85"></SolidColorBrush>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <!-- Sundial brushes -->
+                    <SolidColorBrush x:Key="SundialNightBorderBrush" Color="#B18B4E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialNightBrush" Color="#ECC17E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialDayBorderBrush" Color="#4E93B1"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialDayBrush" Color="#AAD7EA"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunriseBorderBrush" Color="#B18C4E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunriseBrush" Color="#FAEDD6"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunsetBorderBrush" Color="#B18C4E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialSunsetBrush" Color="#FAEDD6"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialMarkerBorderBrush" Color="#B1704E"></SolidColorBrush>
+                    <SolidColorBrush x:Key="SundialMarkerBrush" Color="#E38755"></SolidColorBrush>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
     <Grid ColumnDefinitions="*,Auto,*">
         <!--  Sunset time  -->
         <TextBlock

--- a/LightBulb/Views/Components/DashboardView.axaml
+++ b/LightBulb/Views/Components/DashboardView.axaml
@@ -41,14 +41,14 @@
                 Height="180"
                 EndAngle="{Binding SunriseStart, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
                 StartAngle="{Binding SunsetEnd, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
-                Stroke="#FFAF1A"
+                Stroke="{DynamicResource SundialNightBorderBrush}"
                 StrokeThickness="28" />
             <controls:Arc
                 Width="180"
                 Height="180"
                 EndAngle="{Binding SunriseStart, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
                 StartAngle="{Binding SunsetEnd, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
-                Stroke="#FFD280"
+                Stroke="{DynamicResource SundialNightBrush}"
                 StrokeThickness="26" />
 
             <!--  Day time arc  -->
@@ -57,14 +57,14 @@
                 Height="180"
                 EndAngle="{Binding SunsetStart, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
                 StartAngle="{Binding SunriseEnd, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
-                Stroke="#8AC0FF"
+                Stroke="{DynamicResource SundialDayBorderBrush}"
                 StrokeThickness="28" />
             <controls:Arc
                 Width="180"
                 Height="180"
                 EndAngle="{Binding SunsetStart, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
                 StartAngle="{Binding SunriseEnd, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
-                Stroke="#F2F8FF"
+                Stroke="{DynamicResource SundialDayBrush}"
                 StrokeThickness="26" />
 
             <!--  Sunrise transition  -->
@@ -73,14 +73,14 @@
                 Height="180"
                 EndAngle="{Binding SunriseEnd, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
                 StartAngle="{Binding SunriseStart, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
-                Stroke="#FFC766"
+                Stroke="{DynamicResource SundialSunriseBorderBrush}"
                 StrokeThickness="28" />
             <controls:Arc
                 Width="180"
                 Height="180"
                 EndAngle="{Binding SunriseEnd, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
                 StartAngle="{Binding SunriseStart, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
-                Stroke="#FFEDCD"
+                Stroke="{DynamicResource SundialSunriseBrush}"
                 StrokeThickness="26" />
 
             <!--  Sunset transition  -->
@@ -89,14 +89,14 @@
                 Height="180"
                 EndAngle="{Binding SunsetEnd, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
                 StartAngle="{Binding SunsetStart, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
-                Stroke="#FFC766"
+                Stroke="{DynamicResource SundialSunsetBorderBrush}"
                 StrokeThickness="28" />
             <controls:Arc
                 Width="180"
                 Height="180"
                 EndAngle="{Binding SunsetEnd, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
                 StartAngle="{Binding SunsetStart, Converter={x:Static converters:TimeOnlyToDegreesDoubleConverter.Instance}}"
-                Stroke="#FFEDCD"
+                Stroke="{DynamicResource SundialSunsetBrush}"
                 StrokeThickness="26" />
 
             <!--  Current time position  -->
@@ -104,13 +104,13 @@
                 Width="180"
                 Height="180"
                 Angle="{Binding Instant.TimeOfDay.TotalDays, Converter={x:Static converters:FractionToDegreesConverter.Instance}}"
-                Fill="#FF7733"
+                Fill="{DynamicResource SundialMarkerBorderBrush}"
                 Size="28" />
             <controls:ArcPoint
                 Width="180"
                 Height="180"
                 Angle="{Binding Instant.TimeOfDay.TotalDays, Converter={x:Static converters:FractionToDegreesConverter.Instance}}"
-                Fill="#FFAB85"
+                Fill="{DynamicResource SundialMarkerBrush}"
                 Size="26" />
 
             <!--  Configuration offset  -->

--- a/LightBulb/Views/Components/Settings/AdvancedSettingsTabView.axaml
+++ b/LightBulb/Views/Components/Settings/AdvancedSettingsTabView.axaml
@@ -22,8 +22,29 @@
                 Classes.accent="{DynamicResource UseAccentControls}" />
         </DockPanel>
 
+        <!-- Theme -->
+        <DockPanel Margin="0,16,0,0" ToolTip.Tip="LightBulb UI Theme">
+            <TextBlock
+                VerticalAlignment="Center"
+                DockPanel.Dock="Left"
+                Text="Theme" />
+            <ComboBox
+                HorizontalAlignment="Right"
+                DockPanel.Dock="Right"
+                ItemsSource="{Binding ThemeArray}"
+                SelectedItem="{Binding Theme}"
+                Classes.accent="{DynamicResource UseAccentControls}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <!-- Required for correct Material display, via https://github.com/AvaloniaCommunity/Material.Avalonia/issues/269#issuecomment-1738117187-->
+                        <TextBlock Text="{Binding StringFormat='\{0\}'}" VerticalAlignment="Center"></TextBlock>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+        </DockPanel>
+
         <!--  Auto update  -->
-        <DockPanel Margin="0,16,0,0" ToolTip.Tip="Keep LightBulb updated by automatically installing new versions as they become available">
+        <DockPanel Margin="0,14,0,0" ToolTip.Tip="Keep LightBulb updated by automatically installing new versions as they become available">
             <TextBlock
                 VerticalAlignment="Center"
                 DockPanel.Dock="Left"

--- a/LightBulb/Views/Components/Settings/AdvancedSettingsTabView.axaml
+++ b/LightBulb/Views/Components/Settings/AdvancedSettingsTabView.axaml
@@ -18,7 +18,8 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 DockPanel.Dock="Right"
-                IsChecked="{Binding IsAutoStartEnabled}" />
+                IsChecked="{Binding IsAutoStartEnabled}"
+                Classes.accent="{DynamicResource UseAccentControls}" />
         </DockPanel>
 
         <!--  Auto update  -->
@@ -31,7 +32,8 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 DockPanel.Dock="Right"
-                IsChecked="{Binding IsAutoUpdateEnabled}" />
+                IsChecked="{Binding IsAutoUpdateEnabled}"
+                Classes.accent="{DynamicResource UseAccentControls}" />
         </DockPanel>
 
         <!--  Default to day time  -->
@@ -44,7 +46,8 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 DockPanel.Dock="Right"
-                IsChecked="{Binding IsDefaultToDayConfigurationEnabled}" />
+                IsChecked="{Binding IsDefaultToDayConfigurationEnabled}"
+                Classes.accent="{DynamicResource UseAccentControls}" />
         </DockPanel>
 
         <!--  Pause when full screen  -->
@@ -57,7 +60,8 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 DockPanel.Dock="Right"
-                IsChecked="{Binding IsPauseWhenFullScreenEnabled}" />
+                IsChecked="{Binding IsPauseWhenFullScreenEnabled}"
+                Classes.accent="{DynamicResource UseAccentControls}" />
         </DockPanel>
 
         <!--  Configuration smoothing  -->
@@ -70,7 +74,8 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 DockPanel.Dock="Right"
-                IsChecked="{Binding IsConfigurationSmoothingEnabled}" />
+                IsChecked="{Binding IsConfigurationSmoothingEnabled}"
+                Classes.accent="{DynamicResource UseAccentControls}" />
         </DockPanel>
 
         <!--  Gamma polling  -->
@@ -83,7 +88,8 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 DockPanel.Dock="Right"
-                IsChecked="{Binding IsGammaPollingEnabled}" />
+                IsChecked="{Binding IsGammaPollingEnabled}"
+                Classes.accent="{DynamicResource UseAccentControls}" />
         </DockPanel>
     </StackPanel>
 </UserControl>

--- a/LightBulb/Views/Components/Settings/ApplicationWhitelistSettingsTabView.axaml
+++ b/LightBulb/Views/Components/Settings/ApplicationWhitelistSettingsTabView.axaml
@@ -42,7 +42,8 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 IsChecked="{Binding IsApplicationWhitelistEnabled}"
-                ToolTip.Tip="Pause LightBulb when one of the selected applications is in the foreground" />
+                ToolTip.Tip="Pause LightBulb when one of the selected applications is in the foreground"
+                Classes.accent="{DynamicResource UseAccentControls}" />
         </Grid>
 
         <!--  Whitelisted applications  -->
@@ -69,7 +70,8 @@
                         <CheckBox
                             Content="{Binding Name}"
                             IsChecked="{Binding $parent[ListBoxItem].IsSelected, Mode=OneWay}"
-                            IsHitTestVisible="False" />
+                            IsHitTestVisible="False"
+                            Classes.accent="{DynamicResource UseAccentControls}"/>
                     </Panel>
                 </DataTemplate>
             </ListBox.ItemTemplate>

--- a/LightBulb/Views/Components/Settings/GeneralSettingsTabView.axaml
+++ b/LightBulb/Views/Components/Settings/GeneralSettingsTabView.axaml
@@ -16,7 +16,8 @@
             <TextBox
                 MinWidth="24"
                 HorizontalAlignment="Right"
-                DockPanel.Dock="Right">
+                DockPanel.Dock="Right"
+                Classes.accent="{DynamicResource UseAccentControls}">
                 <Interaction.Behaviors>
                     <behaviors:LostFocusUpdateBindingBehavior Text="{Binding DayTemperature, Converter={x:Static converters:DoubleToStringConverter.Instance}}" />
                 </Interaction.Behaviors>
@@ -30,7 +31,8 @@
             Minimum="2500"
             SmallChange="100"
             TickFrequency="20"
-            Value="{Binding DayTemperature}" />
+            Value="{Binding DayTemperature}"
+            Classes.accent="{DynamicResource UseAccentControls}" />
 
         <!--  Night temperature  -->
         <DockPanel Margin="0,24,0,0" ToolTip.Tip="Color temperature during the night">
@@ -38,7 +40,8 @@
             <TextBox
                 MinWidth="24"
                 HorizontalAlignment="Right"
-                DockPanel.Dock="Right">
+                DockPanel.Dock="Right"
+                Classes.accent="{DynamicResource UseAccentControls}">
                 <Interaction.Behaviors>
                     <behaviors:LostFocusUpdateBindingBehavior Text="{Binding NightTemperature, Converter={x:Static converters:DoubleToStringConverter.Instance}}" />
                 </Interaction.Behaviors>
@@ -52,7 +55,8 @@
             Minimum="2500"
             SmallChange="100"
             TickFrequency="20"
-            Value="{Binding NightTemperature}" />
+            Value="{Binding NightTemperature}"
+            Classes.accent="{DynamicResource UseAccentControls}" />
 
         <!--  Day brightness  -->
         <DockPanel Margin="0,24,0,0">
@@ -73,7 +77,8 @@
             <TextBox
                 MinWidth="24"
                 HorizontalAlignment="Right"
-                DockPanel.Dock="Right">
+                DockPanel.Dock="Right"
+                Classes.accent="{DynamicResource UseAccentControls}">
                 <Interaction.Behaviors>
                     <behaviors:LostFocusUpdateBindingBehavior Text="{Binding DayBrightness, Converter={x:Static converters:FractionToPercentageStringConverter.Instance}}" />
                 </Interaction.Behaviors>
@@ -87,7 +92,8 @@
             Minimum="0.1"
             SmallChange="0.01"
             TickFrequency="0.01"
-            Value="{Binding DayBrightness}" />
+            Value="{Binding DayBrightness}"
+            Classes.accent="{DynamicResource UseAccentControls}" />
 
         <!--  Night brightness  -->
         <DockPanel Margin="0,24,0,0">
@@ -108,7 +114,8 @@
             <TextBox
                 MinWidth="24"
                 HorizontalAlignment="Right"
-                DockPanel.Dock="Right">
+                DockPanel.Dock="Right"
+                Classes.accent="{DynamicResource UseAccentControls}">
                 <Interaction.Behaviors>
                     <behaviors:LostFocusUpdateBindingBehavior Text="{Binding NightBrightness, Converter={x:Static converters:FractionToPercentageStringConverter.Instance}}" />
                 </Interaction.Behaviors>
@@ -122,7 +129,8 @@
             Minimum="0.1"
             SmallChange="0.01"
             TickFrequency="0.01"
-            Value="{Binding NightBrightness}" />
+            Value="{Binding NightBrightness}"
+            Classes.accent="{DynamicResource UseAccentControls}" />
 
         <!--  Configuration transition duration  -->
         <DockPanel Margin="0,24,0,0" ToolTip.Tip="Duration of time it takes to switch between day-time and night-time configurations">
@@ -130,7 +138,8 @@
             <TextBox
                 MinWidth="48"
                 HorizontalAlignment="Right"
-                DockPanel.Dock="Right">
+                DockPanel.Dock="Right"
+                Classes.accent="{DynamicResource UseAccentControls}">
                 <Interaction.Behaviors>
                     <behaviors:LostFocusUpdateBindingBehavior Text="{Binding ConfigurationTransitionDuration, Converter={x:Static converters:TimeSpanToDurationStringConverter.Instance}}" />
                 </Interaction.Behaviors>
@@ -142,7 +151,8 @@
             Maximum="3"
             Minimum="0"
             SmallChange="0.08"
-            Value="{Binding ConfigurationTransitionDuration, Converter={x:Static converters:TimeSpanToHoursDoubleConverter.Instance}}" />
+            Value="{Binding ConfigurationTransitionDuration, Converter={x:Static converters:TimeSpanToHoursDoubleConverter.Instance}}"
+            Classes.accent="{DynamicResource UseAccentControls}" />
 
         <!--  Configuration transition offset  -->
         <DockPanel Margin="0,24,0,0" ToolTip.Tip="Offset that specifies how early or late the transition starts, relative to the sunrise and sunset">
@@ -150,7 +160,8 @@
             <TextBox
                 MinWidth="24"
                 HorizontalAlignment="Right"
-                DockPanel.Dock="Right">
+                DockPanel.Dock="Right"
+                Classes.accent="{DynamicResource UseAccentControls}">
                 <Interaction.Behaviors>
                     <behaviors:LostFocusUpdateBindingBehavior Text="{Binding ConfigurationTransitionOffset, Converter={x:Static converters:FractionToPercentageStringConverter.Instance}}" />
                 </Interaction.Behaviors>
@@ -162,6 +173,7 @@
             Maximum="1"
             Minimum="0"
             SmallChange="0.01"
-            Value="{Binding ConfigurationTransitionOffset}" />
+            Value="{Binding ConfigurationTransitionOffset}"
+            Classes.accent="{DynamicResource UseAccentControls}" />
     </StackPanel>
 </UserControl>

--- a/LightBulb/Views/Components/Settings/LocationSettingsTabView.axaml
+++ b/LightBulb/Views/Components/Settings/LocationSettingsTabView.axaml
@@ -18,13 +18,15 @@
                 Content="Manual"
                 DockPanel.Dock="Left"
                 IsChecked="{Binding IsManualSunriseSunsetEnabled}"
-                ToolTip.Tip="Configure sunrise and sunset manually" />
+                ToolTip.Tip="Configure sunrise and sunset manually"
+                Classes.accent="{DynamicResource UseAccentControls}" />
             <RadioButton
                 HorizontalAlignment="Right"
                 Content="Location-based"
                 DockPanel.Dock="Right"
                 IsChecked="{Binding !IsManualSunriseSunsetEnabled}"
-                ToolTip.Tip="Configure your location and use it to automatically calculate the sunrise and sunset times" />
+                ToolTip.Tip="Configure your location and use it to automatically calculate the sunrise and sunset times"
+                Classes.accent="{DynamicResource UseAccentControls}" />
         </DockPanel>
 
         <!--  Manual  -->
@@ -38,7 +40,8 @@
                 <TextBox
                     MinWidth="24"
                     HorizontalAlignment="Right"
-                    DockPanel.Dock="Right">
+                    DockPanel.Dock="Right"
+                    Classes.accent="{DynamicResource UseAccentControls}">
                     <Interaction.Behaviors>
                         <behaviors:LostFocusUpdateBindingBehavior Text="{Binding ManualSunrise, Converter={x:Static converters:TimeOnlyToStringConverter.Instance}}" />
                     </Interaction.Behaviors>
@@ -50,7 +53,8 @@
                 Maximum="23.99999"
                 Minimum="0"
                 SmallChange="0.25"
-                Value="{Binding ManualSunrise, Converter={x:Static converters:TimeOnlyToHoursDoubleConverter.Instance}}" />
+                Value="{Binding ManualSunrise, Converter={x:Static converters:TimeOnlyToHoursDoubleConverter.Instance}}"
+                Classes.accent="{DynamicResource UseAccentControls}" />
 
             <!--  Sunset time  -->
             <DockPanel Margin="0,16,0,0">
@@ -58,7 +62,8 @@
                 <TextBox
                     MinWidth="24"
                     HorizontalAlignment="Right"
-                    DockPanel.Dock="Right">
+                    DockPanel.Dock="Right"
+                    Classes.accent="{DynamicResource UseAccentControls}">
                     <Interaction.Behaviors>
                         <behaviors:LostFocusUpdateBindingBehavior Text="{Binding ManualSunset, Converter={x:Static converters:TimeOnlyToStringConverter.Instance}}" />
                     </Interaction.Behaviors>
@@ -70,7 +75,8 @@
                 Maximum="23.99999"
                 Minimum="0"
                 SmallChange="0.25"
-                Value="{Binding ManualSunset, Converter={x:Static converters:TimeOnlyToHoursDoubleConverter.Instance}}" />
+                Value="{Binding ManualSunset, Converter={x:Static converters:TimeOnlyToHoursDoubleConverter.Instance}}"
+                Classes.accent="{DynamicResource UseAccentControls}" />
         </StackPanel>
 
         <!--  Location-based  -->
@@ -101,7 +107,8 @@
                     Margin="8,0"
                     VerticalAlignment="Center"
                     IsEnabled="{Binding !IsBusy}"
-                    Text="{Binding LocationQuery}">
+                    Text="{Binding LocationQuery}"
+                    Classes.accent="{DynamicResource UseAccentControls}">
                     <ToolTip.Tip>
                         <TextBlock>
                             <Run Text="Specify your location using geographic coordinates or a search query" />

--- a/LightBulb/Views/Controls/HotKeyTextBox.axaml
+++ b/LightBulb/Views/Controls/HotKeyTextBox.axaml
@@ -7,5 +7,6 @@
         IsReadOnly="True"
         IsUndoEnabled="False"
         Text="{Binding $parent[UserControl].HotKey, Mode=OneWay}"
-        TextAlignment="Center" />
+        TextAlignment="Center"
+        Classes.accent="{DynamicResource UseAccentControls}"/>
 </UserControl>

--- a/LightBulb/Views/MainView.axaml
+++ b/LightBulb/Views/MainView.axaml
@@ -34,6 +34,7 @@
                     Background="{DynamicResource MaterialPrimaryMidBrush}"
                     PointerPressed="HeaderBorder_OnPointerPressed">
                     <Grid ColumnDefinitions="Auto,Auto,*,Auto">
+                        <Border Background="{DynamicResource MaterialSecondaryMidBrush}" Width="32" Height="32" CornerRadius="32" />
                         <!--  On/Off button and logo  -->
                         <ToggleButton
                             Grid.Column="0"
@@ -41,10 +42,10 @@
                             Height="32"
                             Padding="0"
                             VerticalAlignment="Center"
-                            Background="{DynamicResource MaterialSecondaryMidBrush}"
                             IsChecked="{Binding Dashboard.IsEnabled}"
                             Theme="{DynamicResource MaterialIconToggleButton}"
-                            ToolTip.Tip="Toggle LightBulb on/off">
+                            ToolTip.Tip="Toggle LightBulb on/off"
+                            Classes="primary">
                             <ToggleButton.Content>
                                 <materialIcons:MaterialIcon
                                     Width="24"


### PR DESCRIPTION
Closes #298. 

Screenshots:
![image](https://github.com/Tyrrrz/LightBulb/assets/84940819/405c649c-5dd4-419d-b142-760dbb179466)
![image](https://github.com/Tyrrrz/LightBulb/assets/84940819/8a5f3f96-2f5f-4269-91f7-67756d73f7b6)
![image](https://github.com/Tyrrrz/LightBulb/assets/84940819/3d9c6de0-77d4-4d69-aacd-c32d403abcb6)

Notes: 
* Colors are up for debate, feel free to make tweaks.
* This upgrades Avalonia.Material to 3.6; dark mode needs the toggle button rework to be legible.
* All the controls switch to accent color-mode in dark mode, with a boolean resource at the application theme level. TextBox and Slider didn't have the accent color-mode built in for some reason, so I added some extra styling.

Question: Do we want/need to have a specific light/dark theme toggle? Currently, it follows the system theme.