### PR TITLE
Add checkbox support to dialogs and apply a "Don't show again" checkbox to `ShowGammaRangePromptAsync`

### DIFF
--- a/LightBulb/Services/SettingsService.cs
+++ b/LightBulb/Services/SettingsService.cs
@@ -57,6 +57,13 @@ public partial class SettingsService() : SettingsBase(GetFilePath(), SerializerC
         set => SetProperty(ref _isExtendedGammaRangeUnlocked, value);
     }
 
+    private bool _isGammaRangePromptDisabled;
+    public bool IsGammaRangePromptDisabled
+    {
+        get => _isGammaRangePromptDisabled;
+        set => SetProperty(ref _isGammaRangePromptDisabled, value);
+    }
+
     // General
 
     public double MinimumTemperature => 500;

--- a/LightBulb/ViewModels/Dialogs/MessageBoxViewModel.cs
+++ b/LightBulb/ViewModels/Dialogs/MessageBoxViewModel.cs
@@ -21,6 +21,20 @@ public partial class MessageBoxViewModel : DialogViewModelBase
     [NotifyPropertyChangedFor(nameof(ButtonsCount))]
     private string? _cancelButtonText = "Cancel";
 
+    private bool _isCheckboxVisible;
+    public bool IsCheckboxVisible
+    {
+        get => _isCheckboxVisible;
+        set => SetProperty(ref _isCheckboxVisible, value);
+    }
+
+    private bool _isCheckboxChecked;
+    public bool IsCheckboxChecked
+    {
+        get => _isCheckboxChecked;
+        set => SetProperty(ref _isCheckboxChecked, value);
+    }
+
     public bool IsDefaultButtonVisible => !string.IsNullOrWhiteSpace(DefaultButtonText);
 
     public bool IsCancelButtonVisible => !string.IsNullOrWhiteSpace(CancelButtonText);

--- a/LightBulb/ViewModels/MainViewModel.cs
+++ b/LightBulb/ViewModels/MainViewModel.cs
@@ -119,7 +119,10 @@ public partial class MainViewModel(
 
     private async Task ShowGammaRangePromptAsync()
     {
-        if (settingsService.IsExtendedGammaRangeUnlocked)
+        if (
+            settingsService.IsExtendedGammaRangeUnlocked
+            || settingsService.IsGammaRangePromptDisabled
+        )
             return;
 
         var dialog = viewModelManager.CreateMessageBoxViewModel(
@@ -133,9 +136,17 @@ public partial class MainViewModel(
             "FIX",
             "CLOSE"
         );
+        dialog.IsCheckboxVisible = true;
 
         if (await dialogManager.ShowDialogAsync(dialog) != true)
+        {
+            if (dialog.IsCheckboxChecked)
+            {
+                settingsService.IsGammaRangePromptDisabled = true;
+                settingsService.Save();
+            }
             return;
+        }
 
         settingsService.IsExtendedGammaRangeUnlocked = true;
         settingsService.Save();

--- a/LightBulb/Views/Dialogs/MessageBoxView.axaml
+++ b/LightBulb/Views/Dialogs/MessageBoxView.axaml
@@ -31,6 +31,19 @@
             </ScrollViewer>
         </Border>
 
+        <CheckBox
+            Grid.Row="2"
+            Margin = "16"
+            IsVisible="{Binding IsCheckboxVisible}"
+            IsChecked="{Binding IsCheckboxChecked}">
+            <CheckBox.Styles>
+                <Style Selector="CheckBox">
+                    <Setter Property="FontSize" Value="12" />
+                </Style>
+            </CheckBox.Styles>
+            Don't show again
+        </CheckBox>
+        
         <UniformGrid
             Grid.Row="2"
             Margin="16"


### PR DESCRIPTION
<!--

**Important**

This pull request should be linked to an issue that describes the problem it addresses.
If there is no corresponding issue yet, please create one first.

An open issue provides a good place to iron out technical requirements and discuss potential solutions.
Creating a pull request without prior discussion may very likely lead to wasted effort.

-->

<!-- Please specify the issue(s) addressed by this pull request: -->

I've been using the application for a few days and don't want to modify the registry to unlock the gamma range. I've found the popup quite annoying, so maybe adding basic checkbox support in the dialogs would be a good idea for cases like this.

<!--

Also keep in mind:

- Pull requests should be as small as possible. Split larger changes into multiple pull requests if needed.
- Follow the coding style and conventions already established in the project. When in doubt, ask in the comments.
- You can add review comments to your own code. Use this to highlight something important or to seek further input from reviewers.

-->
