### PR TITLE
Add support for application blacklist

### DIFF
--- a/LightBulb/Services/SettingsService.cs
+++ b/LightBulb/Services/SettingsService.cs
@@ -19,21 +19,19 @@ namespace LightBulb.Services;
 [INotifyPropertyChanged]
 public partial class SettingsService() : SettingsBase(GetFilePath(), SerializerContext.Default)
 {
-    private readonly RegistrySwitch<int> _extendedGammaRangeSwitch =
-        new(
-            RegistryHive.LocalMachine,
-            @"Software\Microsoft\Windows NT\CurrentVersion\ICM",
-            "GdiICMGammaRange",
-            256
-        );
+    private readonly RegistrySwitch<int> _extendedGammaRangeSwitch = new(
+        RegistryHive.LocalMachine,
+        @"Software\Microsoft\Windows NT\CurrentVersion\ICM",
+        "GdiICMGammaRange",
+        256
+    );
 
-    private readonly RegistrySwitch<string> _autoStartSwitch =
-        new(
-            RegistryHive.CurrentUser,
-            @"Software\Microsoft\Windows\CurrentVersion\Run",
-            Program.Name,
-            $"\"{Program.ExecutableFilePath}\" {StartOptions.IsInitiallyHiddenArgument}"
-        );
+    private readonly RegistrySwitch<string> _autoStartSwitch = new(
+        RegistryHive.CurrentUser,
+        @"Software\Microsoft\Windows\CurrentVersion\Run",
+        Program.Name,
+        $"\"{Program.ExecutableFilePath}\" {StartOptions.IsInitiallyHiddenArgument}"
+    );
 
     private bool _isFirstTimeExperienceEnabled = true;
     public bool IsFirstTimeExperienceEnabled
@@ -204,6 +202,22 @@ public partial class SettingsService() : SettingsBase(GetFilePath(), SerializerC
     {
         get => _whitelistedApplications;
         set => SetProperty(ref _whitelistedApplications, value);
+    }
+
+    // Application blacklist
+
+    private bool _isApplicationBlacklistEnabled;
+    public bool IsApplicationBlacklistEnabled
+    {
+        get => _isApplicationBlacklistEnabled;
+        set => SetProperty(ref _isApplicationBlacklistEnabled, value);
+    }
+
+    private IReadOnlyList<ExternalApplication>? _blacklistedApplications;
+    public IReadOnlyList<ExternalApplication>? BlacklistedApplications
+    {
+        get => _blacklistedApplications;
+        set => SetProperty(ref _blacklistedApplications, value);
     }
 
     // HotKeys

--- a/LightBulb/ViewModels/Components/DashboardViewModel.cs
+++ b/LightBulb/ViewModels/Components/DashboardViewModel.cs
@@ -370,7 +370,16 @@ public partial class DashboardViewModel : ViewModelBase
                 _externalApplicationService.TryGetForegroundApplication()
             );
 
-        IsPaused = IsPausedByFullScreen() || IsPausedByWhitelistedApplication();
+        bool IsUpdateForcedByBlacklist() =>
+            _settingsService.IsApplicationBlacklistEnabled
+            && _settingsService.BlacklistedApplications is not null
+            && _settingsService.BlacklistedApplications.Contains(
+                _externalApplicationService.TryGetForegroundApplication()
+            );
+
+        IsPaused =
+            !IsUpdateForcedByBlacklist()
+            && (IsPausedByFullScreen() || IsPausedByWhitelistedApplication());
     }
 
     [RelayCommand]

--- a/LightBulb/Views/Components/Settings/ApplicationWhitelistSettingsTabView.axaml
+++ b/LightBulb/Views/Components/Settings/ApplicationWhitelistSettingsTabView.axaml
@@ -5,71 +5,80 @@
     xmlns:materialIcons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
     xmlns:settings="clr-namespace:LightBulb.ViewModels.Components.Settings"
     x:Name="UserControl"
-    x:DataType="settings:ApplicationWhitelistSettingsTabViewModel"
-    Loaded="UserControl_OnLoaded"
-    Unloaded="UserControl_OnUnloaded">
+    x:DataType="settings:ApplicationWhitelistSettingsTabViewModel">
     <StackPanel Margin="16" Orientation="Vertical">
-        <!--  Is enabled  -->
-        <Grid ColumnDefinitions="*,Auto,Auto">
-            <!--  Label  -->
+        
+        <!-- Enable whitelist -->
+        <Grid ColumnDefinitions="*,Auto"
+              Margin="0 0 0 6"
+              ToolTip.Tip="Pause LightBulb when one of the selected applications is in the foreground" >
             <TextBlock
                 Grid.Column="0"
                 VerticalAlignment="Center"
-                Text="Application whitelist" />
+                Text="Whitelist enabled" />
 
-            <!--  Refresh  -->
-            <Button
+            <ToggleSwitch
                 Grid.Column="1"
-                Margin="8,0,0,0"
-                Padding="4"
+                HorizontalAlignment="Right"
                 VerticalAlignment="Center"
-                Command="{Binding RefreshApplicationsCommand}"
-                Theme="{DynamicResource MaterialFlatButton}"
-                ToolTip.Tip="Refresh running applications">
+                IsChecked="{Binding IsApplicationWhitelistEnabled}" />
+        </Grid>
+        
+        <!-- Enable blacklist -->
+        <Grid ColumnDefinitions="*,Auto"
+              Margin="0 0 0 6"
+              ToolTip.Tip="Force LightBulb to run when selected applications is in the foreground and 'Pause in fullscreen' settings is enabled">
+            <TextBlock
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="Blacklist enabled" />
+
+            <ToggleSwitch
+                Grid.Column="1"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Center"
+                IsChecked="{Binding IsApplicationBlacklistEnabled}" />
+        </Grid>
+
+        <!--  Refresh application list  -->
+        <Button
+            VerticalAlignment="Center"
+            Command="{Binding RefreshApplicationsCommand}"
+            Theme="{DynamicResource MaterialFlatButton}">
+            
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock VerticalAlignment="Center">Refresh running applications</TextBlock>
                 <materialIcons:MaterialIcon
                     Width="24"
                     Height="24"
-                    Kind="Refresh" />
-            </Button>
+                    Kind="Refresh" 
+                    Margin="4 0 0 0"/>
+            </StackPanel>
+        </Button>
 
-            <!--  Toggle  -->
-            <ToggleSwitch
-                Grid.Column="2"
-                Margin="8,0,0,0"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Center"
-                IsChecked="{Binding IsApplicationWhitelistEnabled}"
-                ToolTip.Tip="Pause LightBulb when one of the selected applications is in the foreground" />
-        </Grid>
-
-        <!--  Whitelisted applications  -->
-        <ListBox
-            x:Name="WhitelistedApplicationsListBox"
+        <!-- Applications -->
+        <ItemsControl
             Margin="0,8,0,0"
-            IsEnabled="{Binding IsApplicationWhitelistEnabled}"
             ItemsSource="{Binding Applications}"
             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-            ScrollViewer.VerticalScrollBarVisibility="Disabled"
-            SelectionChanged="WhitelistedApplicationsListBox_OnSelectionChanged"
-            SelectionMode="Multiple,Toggle">
-            <ListBox.Styles>
-                <Style Selector="ListBox">
-                    <Style Selector="^ ListBoxItem">
-                        <Setter Property="Padding" Value="0,4" />
-                    </Style>
-                </Style>
-            </ListBox.Styles>
-            <ListBox.ItemTemplate>
+            ScrollViewer.VerticalScrollBarVisibility="Disabled">
+            <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <Panel Background="Transparent" ToolTip.Tip="{Binding ExecutableFilePath}">
-                        <!--  HACK: show a checkbox that does nothing but reflects the row selection status  -->
-                        <CheckBox
-                            Content="{Binding Name}"
-                            IsChecked="{Binding $parent[ListBoxItem].IsSelected, Mode=OneWay}"
-                            IsHitTestVisible="False" />
-                    </Panel>
+                    
+                    <Grid ColumnDefinitions="*,Auto" Margin="0, 4">
+                        <TextBlock
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="{Binding Application.Name}"
+                            ToolTip.Tip="{Binding Application.ExecutableFilePath}" />
+
+                        <ComboBox
+                            Grid.Column="1"
+                            ItemsSource="{Binding AvailableExclusionTypes}"
+                            SelectedValue="{Binding AppExclusionType}" />
+                    </Grid>
                 </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
     </StackPanel>
 </UserControl>

--- a/LightBulb/Views/Components/Settings/ApplicationWhitelistSettingsTabView.axaml.cs
+++ b/LightBulb/Views/Components/Settings/ApplicationWhitelistSettingsTabView.axaml.cs
@@ -1,67 +1,10 @@
-﻿using System;
-using System.Linq;
-using Avalonia.Collections;
-using Avalonia.Controls;
-using Avalonia.Interactivity;
-using LightBulb.Framework;
-using LightBulb.Models;
-using LightBulb.Utils;
-using LightBulb.Utils.Extensions;
+﻿using LightBulb.Framework;
 using LightBulb.ViewModels.Components.Settings;
 
 namespace LightBulb.Views.Components.Settings;
 
 public partial class ApplicationWhitelistSettingsTabView
-    : UserControl<ApplicationWhitelistSettingsTabViewModel>,
-        IDisposable
+    : UserControl<ApplicationWhitelistSettingsTabViewModel>
 {
-    private readonly DisposableCollector _eventRoot = new();
-
     public ApplicationWhitelistSettingsTabView() => InitializeComponent();
-
-    private void UserControl_OnLoaded(object? sender, RoutedEventArgs args)
-    {
-        DataContext.RefreshApplicationsCommand.Execute(null);
-
-        _eventRoot.Add(
-            // This hack is required to avoid having to use an ObservableCollection<T> on the view model
-            DataContext.WatchProperty(
-                o => o.WhitelistedApplications,
-                () =>
-                    WhitelistedApplicationsListBox.SelectedItems = new AvaloniaList<object>(
-                        DataContext.WhitelistedApplications ?? []
-                    ),
-                true
-            )
-        );
-    }
-
-    private void UserControl_OnUnloaded(object? sender, RoutedEventArgs args) =>
-        _eventRoot.Dispose();
-
-    // This hack is required to avoid having to use an ObservableCollection<T> on the view model
-    private void WhitelistedApplicationsListBox_OnSelectionChanged(
-        object? sender,
-        SelectionChangedEventArgs args
-    )
-    {
-        var applications = WhitelistedApplicationsListBox
-            .SelectedItems?.Cast<ExternalApplication>()
-            .ToArray();
-
-        // Don't update the view model if the list hasn't changed.
-        // This is important to avoid potential infinite loops.
-        if (
-            applications is not null
-            && DataContext.WhitelistedApplications is not null
-            && applications.SequenceEqual(DataContext.WhitelistedApplications)
-        )
-        {
-            return;
-        }
-
-        DataContext.WhitelistedApplications = applications;
-    }
-
-    public void Dispose() => _eventRoot.Dispose();
 }


### PR DESCRIPTION
You're not allowing to create issues as feature requests, so I'm creating a PR for a feature I need myself.

This feature adds a new "blacklist" alongside whitelist. Blacklist would force LightBulb to run even when "Pause in fullscreen" is enabled. Reason for such a feature: I have pause in fullscreen enabled, so I can watch YT or game without orange tint. But I also work via RDP, so from the perspective of LightBulb I'm fullscreen and orange tint is not enabled because of the first setting.

Updated UI:
![image](https://github.com/user-attachments/assets/0128e00f-c547-49eb-a517-0dc8453779e5)


Points for discussion:
1. Whitelist and blacklist names should be switched. Currently adding an app to whitelist will disable LightBulb for that app, but that seems like definition of "blacklist" - to exclude something. Right now it feels strange to blacklist an app for it to always be tinted.
2. No unit tests? Should I introduce some? Feels weird without them. Would need some minor refactoring though, could introduce that in a separate PR