### PR TITLE
Adjust the physical monitor brightness directly instead of multiplying gamma

### DIFF
--- a/LightBulb.PlatformInterop/Internal/NativeMethods.Dxva2.cs
+++ b/LightBulb.PlatformInterop/Internal/NativeMethods.Dxva2.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace LightBulb.PlatformInterop.Internal;
+
+[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+public struct PhysicalMonitor
+{
+    public nint Handle;
+
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+    public string Description;
+}
+
+internal static partial class NativeMethods
+{
+    [DllImport("dxva2.dll", SetLastError = true)]
+    public static extern bool GetNumberOfPhysicalMonitorsFromHMONITOR(
+        nint hMonitor,
+        out uint pdwNumberOfPhysicalMonitors
+    );
+
+    [DllImport("dxva2.dll", SetLastError = true)]
+    public static extern bool GetPhysicalMonitorsFromHMONITOR(
+        nint hMonitor,
+        uint dwPhysicalMonitorArraySize,
+        [Out] PhysicalMonitor[] pPhysicalMonitorArray
+    );
+
+    [DllImport("dxva2.dll", SetLastError = true)]
+    public static extern bool SetMonitorBrightness(nint hMonitor, uint dwNewBrightness);
+
+    [DllImport("dxva2.dll", SetLastError = true)]
+    public static extern bool DestroyPhysicalMonitors(
+        uint dwPhysicalMonitorArraySize,
+        [In] PhysicalMonitor[] pPhysicalMonitorArray
+    );
+}

--- a/LightBulb/Services/GammaService.cs
+++ b/LightBulb/Services/GammaService.cs
@@ -167,10 +167,12 @@ public partial class GammaService : IDisposable
         foreach (var deviceContext in _deviceContexts)
         {
             deviceContext.SetGamma(
-                GetRed(configuration) * configuration.Brightness,
-                GetGreen(configuration) * configuration.Brightness,
-                GetBlue(configuration) * configuration.Brightness
+                GetRed(configuration),
+                GetGreen(configuration),
+                GetBlue(configuration)
             );
+
+            deviceContext.SetBrightness(configuration.Brightness);
         }
 
         _isUpdatingGamma = false;


### PR DESCRIPTION
There is no open issue for this, but I needed this feature regardless. If you feel it can be merged, or needs some extra work, I am happy to help get it into a mergeable state, otherwise I'll just maintain it in my fork. 

It's great that this app already supports adjustable brightness, but the current implementation just multiplies the gamma which I think is effectively useless. The monitor backlight will still be running at full power, and the result on my monitor (and presumably many others) is a dim, hard to see, but still bright display. 

This PR adjusts the monitor brightness directly so the backlight will dim per the configured values.

This feature could be possibly be improved in a couple ways (but it was not needed for my case so I didn't bother for now)
- There could be a setting which falls back to using gamma multiplication (e.g. if the user's display or OS does not support this)
- The physical screen brightness could have a fallback using `DeviceIoControl` which may offer compatibility with a wider variety of screens.