### PR TITLE
Ease settings restrictions on brightness and offset

### DIFF
--- a/LightBulb/Services/SettingsService.cs
+++ b/LightBulb/Services/SettingsService.cs
@@ -47,7 +47,7 @@ public partial class SettingsService() : SettingsBase(GetFilePath(), SerializerC
 
     public double MaximumTemperature => 20_000;
 
-    public double MinimumBrightness => 0.1;
+    public double MinimumBrightness => 0.01;
 
     public double MaximumBrightness => 1;
 

--- a/LightBulb/ViewModels/Components/Settings/GeneralSettingsTabViewModel.cs
+++ b/LightBulb/ViewModels/Components/Settings/GeneralSettingsTabViewModel.cs
@@ -107,6 +107,6 @@ public class GeneralSettingsTabViewModel(SettingsService settingsService)
     public double ConfigurationTransitionOffset
     {
         get => SettingsService.ConfigurationTransitionOffset;
-        set => SettingsService.ConfigurationTransitionOffset = Math.Clamp(value, 0, 1);
+        set => SettingsService.ConfigurationTransitionOffset = Math.Clamp(value, 0, 2);
     }
 }

--- a/LightBulb/Views/Components/Settings/GeneralSettingsTabView.axaml
+++ b/LightBulb/Views/Components/Settings/GeneralSettingsTabView.axaml
@@ -107,7 +107,7 @@
             IsSnapToTickEnabled="True"
             LargeChange="0.1"
             Maximum="1"
-            Minimum="0.1"
+            Minimum="0.01"
             SmallChange="0.01"
             TickFrequency="0.01"
             Value="{Binding NightBrightness}" />

--- a/LightBulb/Views/Components/Settings/GeneralSettingsTabView.axaml
+++ b/LightBulb/Views/Components/Settings/GeneralSettingsTabView.axaml
@@ -143,7 +143,7 @@
         <Slider
             Margin="0,12,0,0"
             LargeChange="0.05"
-            Maximum="1"
+            Maximum="2"
             Minimum="0"
             SmallChange="0.01"
             Value="{Binding ConfigurationTransitionOffset}" />


### PR DESCRIPTION
- The current implementation sets the minimum brightness to 10%. I guess this might be reasonable for the gamma multiplication approach but many displays allow 0% or 1% physical brightness for comfortable viewing at night in a dark room - while 10% is far too bright. With that being considered, this probably shouldn't be merged before #387 
- The current offset parameter only allows for a shift of 100% of the transition duration. This is very limiting. The best solution here would allow the offset to be an arbitrary duration (rather than a multiplication of the transition duration) but I found that a transition duration of 1hr and an offset of 170% was the right number for my locale, where the official sunrise is 4am, official sunset it 10pm, but in reality it's not actually bright until 5:30-6am. With an arbitrary offset timespan I would have probably set it to ~1.5hr, but this was not possible. 

Feel free to not merge, like I mentioned in my previous PR this is what I needed to get it working for me and I'm happy to maintain this in my own fork if you don't think it has value here. 